### PR TITLE
108 create edithouseholdscreen

### DIFF
--- a/navigators/SelectedHouseholdTopTabNav.tsx
+++ b/navigators/SelectedHouseholdTopTabNav.tsx
@@ -13,7 +13,8 @@ import { sliceStringToLengthAddEllipsis } from '../library/utils';
 import SelectedHouseholdScreen from '../screens/SelectedHouseholdScreen';
 import CurrentWeek from '../screens/statistics/CurrentWeek';
 import LastWeek from '../screens/statistics/LastWeek';
-import { useAppSelector } from '../store/hooks';
+import { useAppDispatch, useAppSelector } from '../store/hooks';
+import { updateSelectedHouseholdName } from '../store/households/householdsActions';
 import { selectMemberForUserInSelectedHousehold } from '../store/members/membersSelectors';
 import { selectSelectedHousehold } from '../store/user/userSelectors';
 import { RootStackParamList } from './RootStackNavigator';
@@ -33,13 +34,13 @@ type Props = CompositeScreenProps<
 
 export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
   const [showEditHouseholdName, setShowEditHouseholdName] = useState(false);
-  const [newHouseholdName, setNewHouseholdName] = useState(
-    selectSelectedHousehold.name,
-  );
+  const [newHouseholdName, setNewHouseholdName] = useState('');
   const selectedHousehold = useAppSelector(selectSelectedHousehold);
   const memberForSelectedHousehold = useAppSelector(
     selectMemberForUserInSelectedHousehold,
   );
+
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     navigation.setOptions({
@@ -62,7 +63,9 @@ export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
   }, [navigation, selectedHousehold, memberForSelectedHousehold]);
 
   const handleChangeHouseholdName = () => {
-    console.log(newHouseholdName);
+    dispatch(updateSelectedHouseholdName(newHouseholdName.trim()));
+    setShowEditHouseholdName(false);
+    setNewHouseholdName('');
   };
 
   return (

--- a/navigators/SelectedHouseholdTopTabNav.tsx
+++ b/navigators/SelectedHouseholdTopTabNav.tsx
@@ -16,6 +16,7 @@ import LastWeek from '../screens/statistics/LastWeek';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { updateSelectedHouseholdName } from '../store/households/householdsActions';
 import { selectMemberForUserInSelectedHousehold } from '../store/members/membersSelectors';
+import { useSelectedHousehold } from '../store/user/hooks';
 import { selectSelectedHousehold } from '../store/user/userSelectors';
 import { RootStackParamList } from './RootStackNavigator';
 
@@ -39,8 +40,8 @@ export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
   const memberForSelectedHousehold = useAppSelector(
     selectMemberForUserInSelectedHousehold,
   );
-
   const dispatch = useAppDispatch();
+  useSelectedHousehold();
 
   useEffect(() => {
     navigation.setOptions({

--- a/navigators/SelectedHouseholdTopTabNav.tsx
+++ b/navigators/SelectedHouseholdTopTabNav.tsx
@@ -4,7 +4,8 @@ import {
 } from '@react-navigation/material-top-tabs';
 import { CompositeScreenProps } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Button, Dialog, Portal, Text, TextInput } from 'react-native-paper';
 import DoubleHeaderIcon from '../components/DoubleHeaderIcon';
 import ProfileIconButton from '../components/ProfileIconButton';
 import { SubHeaderStatsScreens } from '../components/SubHeaderStatsScreens';
@@ -31,6 +32,10 @@ type Props = CompositeScreenProps<
 >;
 
 export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
+  const [showEditHouseholdName, setShowEditHouseholdName] = useState(false);
+  const [newHouseholdName, setNewHouseholdName] = useState(
+    selectSelectedHousehold.name,
+  );
   const selectedHousehold = useAppSelector(selectSelectedHousehold);
   const memberForSelectedHousehold = useAppSelector(
     selectMemberForUserInSelectedHousehold,
@@ -43,8 +48,7 @@ export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
         <>
           {!!memberForSelectedHousehold?.isOwner ? (
             <DoubleHeaderIcon
-              //FIXME: add navigation to edit household
-              navigateToEditHousehold={() => navigation.navigate('Profile')}
+              navigateToEditHousehold={() => setShowEditHouseholdName(true)}
               navigateToProfile={() => navigation.navigate('Profile')}
             />
           ) : (
@@ -57,26 +61,60 @@ export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
     });
   }, [navigation, selectedHousehold, memberForSelectedHousehold]);
 
+  const handleChangeHouseholdName = () => {
+    console.log(newHouseholdName);
+  };
+
   return (
-    <Tab.Navigator
-      initialRouteName="SelectedHousehold"
-      tabBar={(props) => <SubHeaderStatsScreens {...props} />}
-    >
-      <Tab.Screen
-        name="SelectedHousehold"
-        component={SelectedHouseholdScreen}
-        options={{ title: 'idag' }}
-      />
-      <Tab.Screen
-        name="StatsCurrentWeek"
-        component={CurrentWeek}
-        options={{ title: 'nuvarande veckan' }}
-      />
-      <Tab.Screen
-        name="StatsLastWeek"
-        component={LastWeek}
-        options={{ title: 'förra veckan' }}
-      />
-    </Tab.Navigator>
+    <>
+      <Tab.Navigator
+        initialRouteName="SelectedHousehold"
+        tabBar={(props) => <SubHeaderStatsScreens {...props} />}
+      >
+        <Tab.Screen
+          name="SelectedHousehold"
+          component={SelectedHouseholdScreen}
+          options={{ title: 'idag' }}
+        />
+        <Tab.Screen
+          name="StatsCurrentWeek"
+          component={CurrentWeek}
+          options={{ title: 'nuvarande veckan' }}
+        />
+        <Tab.Screen
+          name="StatsLastWeek"
+          component={LastWeek}
+          options={{ title: 'förra veckan' }}
+        />
+      </Tab.Navigator>
+      <Portal>
+        <Dialog
+          visible={showEditHouseholdName}
+          onDismiss={() => setShowEditHouseholdName(false)}
+        >
+          <Dialog.Title>
+            <Text>Byta hushållsnamn</Text>
+          </Dialog.Title>
+          <Dialog.Content>
+            <TextInput
+              value={newHouseholdName}
+              onChangeText={setNewHouseholdName}
+            />
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setShowEditHouseholdName(false)}>
+              Avbryt
+            </Button>
+            <Button
+              style={{ paddingHorizontal: 30 }}
+              mode="contained"
+              onPress={() => handleChangeHouseholdName()}
+            >
+              OK
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    </>
   );
 }

--- a/navigators/SelectedHouseholdTopTabNav.tsx
+++ b/navigators/SelectedHouseholdTopTabNav.tsx
@@ -16,7 +16,6 @@ import LastWeek from '../screens/statistics/LastWeek';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { updateSelectedHouseholdName } from '../store/households/householdsActions';
 import { selectMemberForUserInSelectedHousehold } from '../store/members/membersSelectors';
-import { useSelectedHousehold } from '../store/user/hooks';
 import { selectSelectedHousehold } from '../store/user/userSelectors';
 import { RootStackParamList } from './RootStackNavigator';
 
@@ -41,7 +40,7 @@ export default function SelectedHouseholdTopTabNav({ navigation }: Props) {
     selectMemberForUserInSelectedHousehold,
   );
   const dispatch = useAppDispatch();
-  useSelectedHousehold();
+  // useSelectedHousehold();
 
   useEffect(() => {
     navigation.setOptions({

--- a/screens/JoinHouseholdScreen.tsx
+++ b/screens/JoinHouseholdScreen.tsx
@@ -1,5 +1,4 @@
-import { useFocusEffect } from '@react-navigation/native';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import {
   ActivityIndicator,
@@ -9,41 +8,25 @@ import {
   TextInput,
 } from 'react-native-paper';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { getHouseholdsByUserId } from '../store/households/householdsActions';
-import { getMembersBySelectedHousehold } from '../store/members/membersActions';
 import { addRequest } from '../store/requests/requestsActions';
 import {
   selectRequestError,
   selectRequestIsLoading,
 } from '../store/requests/requestsSelectors';
-import { getMembersByCurrentUserId } from '../store/user/userActions';
-import { selectCurrentUser } from '../store/user/userSelectors';
+import {
+  useSelectedHouseholdData,
+  useUserAuthState,
+} from '../store/user/hooks';
 
 export default function JoinHouseholdScreen() {
+  useUserAuthState();
+  useSelectedHouseholdData();
   const [houseCode, setHouseCode] = useState('');
   const [showConfirmationDialog, setShowConfirmationDialog] = useState(false);
   const [showValidationDialog, setShowValidationDialog] = useState(false);
   const dispatch = useAppDispatch();
   const requestIsLoading = useAppSelector(selectRequestIsLoading);
   const requestError = useAppSelector(selectRequestError);
-  const user = useAppSelector(selectCurrentUser);
-
-  // testing...
-  useFocusEffect(
-    useCallback(() => {
-      if (user) {
-        dispatch(getMembersByCurrentUserId())
-          .unwrap()
-          .then(() => {
-            dispatch(getHouseholdsByUserId())
-              .unwrap()
-              .then(() => {
-                dispatch(getMembersBySelectedHousehold());
-              });
-          });
-      }
-    }, [dispatch, user, showConfirmationDialog]),
-  );
 
   const handleSubmitCode = () => {
     if (!houseCode) {

--- a/screens/debug/TestHouseholds.tsx
+++ b/screens/debug/TestHouseholds.tsx
@@ -7,7 +7,7 @@ import { RootStackParamList } from '../../navigators/RootStackNavigator';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   addHousehold,
-  updateHouseholdName,
+  updateSelectedHouseholdName,
 } from '../../store/households/householdsActions';
 import { selectAllHouseholdsByCurrentUser } from '../../store/households/householdsSelectors';
 import { selectSelectedHousehold } from '../../store/user/userSelectors';
@@ -46,7 +46,7 @@ export default function TestHouseholds({ navigation }: Props) {
       ...household,
       name: 'another family with a really long name',
     };
-    dispatch(updateHouseholdName(updates));
+    dispatch(updateSelectedHouseholdName(updates.name));
   };
 
   return (

--- a/store/households/householdsActions.ts
+++ b/store/households/householdsActions.ts
@@ -95,19 +95,26 @@ export const getHouseholdByCode = createAsyncThunk<Household, string>(
   },
 );
 
-export const updateHouseholdName = createAppAsyncThunk<Household, Household>(
-  'households/updateHouseholdName',
-  async (household, thunkApi) => {
-    try {
-      await updateDoc(doc(db, 'households', household.id), {
-        name: household.name,
-      });
-      return household;
-    } catch (error) {
-      return thunkApi.rejectWithValue(`Error updating household: ${error}`);
-    }
+export const updateSelectedHouseholdName = createAppAsyncThunk<
+  {
+    housholdId: string;
+    housholdName: string;
   },
-);
+  string
+>('households/updateHouseholdName', async (newName, thunkApi) => {
+  const state = thunkApi.getState();
+  try {
+    await updateDoc(doc(db, 'households', state.user.selectedHousehold!.id), {
+      name: newName,
+    });
+    return {
+      housholdId: state.user.selectedHousehold!.id,
+      housholdName: newName,
+    };
+  } catch (error) {
+    return thunkApi.rejectWithValue(`Error updating household: ${error}`);
+  }
+});
 
 // export const getHouseholds = createAppAsyncThunk<Household[]>(
 //   'households/getHouseholds',

--- a/store/households/householdsSlice.ts
+++ b/store/households/householdsSlice.ts
@@ -4,7 +4,7 @@ import { Household } from '../../types';
 import {
   addHousehold,
   getHouseholdsByUserId,
-  updateHouseholdName,
+  updateSelectedHouseholdName,
 } from './householdsActions';
 
 // state
@@ -49,13 +49,15 @@ const householdsSlice = createSlice({
       //     state.selectedHousehold = action.payload;
       //   }
       // })
-      .addCase(updateHouseholdName.pending, (state) => {
+      .addCase(updateSelectedHouseholdName.pending, (state) => {
         state.isLoading = true;
       })
-      .addCase(updateHouseholdName.fulfilled, (state, action) => {
-        const household = state.list.find((h) => h.id === action.payload.id);
+      .addCase(updateSelectedHouseholdName.fulfilled, (state, action) => {
+        const household = state.list.find(
+          (h) => h.id === action.payload.housholdId,
+        );
         if (household) {
-          household.name = action.payload.name;
+          household.name = action.payload.housholdName;
         }
         state.isLoading = false;
       });

--- a/store/user/hooks.ts
+++ b/store/user/hooks.ts
@@ -63,22 +63,22 @@ export async function useHouseholds() {
   }, [dispatch]);
 }
 
-export async function useSelectedHousehold() {
-  const dispatch = useAppDispatch();
-  useEffect(() => {
-    const fetchData = async () => {
-      await dispatch(getMembersBySelectedHousehold());
-      await dispatch(getTasksBySelectedHousehold());
-      await dispatch(getCompletedTasksByHousehold());
-      await dispatch(getRequestsBySelectedHouseholdId());
-    };
+// export async function useSelectedHousehold() {
+//   const dispatch = useAppDispatch();
+//   useEffect(() => {
+//     const fetchData = async () => {
+//       await dispatch(getMembersBySelectedHousehold());
+//       await dispatch(getTasksBySelectedHousehold());
+//       await dispatch(getCompletedTasksByHousehold());
+//       await dispatch(getRequestsBySelectedHouseholdId());
+//     };
 
-    const id = setInterval(fetchData, 5000); // http "polling"
-    // obs: loading states vill ni typiskt inte ha i samband med polling.
+//     const id = setInterval(fetchData, 5000); // http "polling"
+//     // obs: loading states vill ni typiskt inte ha i samband med polling.
 
-    return () => clearInterval(id);
-  }, [dispatch]);
-}
+//     return () => clearInterval(id);
+//   }, [dispatch]);
+// }
 
 export async function useSelectedHouseholdData() {
   const dispatch = useAppDispatch();

--- a/store/user/hooks.ts
+++ b/store/user/hooks.ts
@@ -63,6 +63,23 @@ export async function useHouseholds() {
   }, [dispatch]);
 }
 
+export async function useSelectedHousehold() {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    const fetchData = async () => {
+      await dispatch(getMembersBySelectedHousehold());
+      await dispatch(getTasksBySelectedHousehold());
+      await dispatch(getCompletedTasksByHousehold());
+      await dispatch(getRequestsBySelectedHouseholdId());
+    };
+
+    const id = setInterval(fetchData, 5000); // http "polling"
+    // obs: loading states vill ni typiskt inte ha i samband med polling.
+
+    return () => clearInterval(id);
+  }, [dispatch]);
+}
+
 export async function useSelectedHouseholdData() {
   const dispatch = useAppDispatch();
   useFocusEffect(

--- a/store/user/userSlice.ts
+++ b/store/user/userSlice.ts
@@ -3,7 +3,10 @@ import { createSlice } from '@reduxjs/toolkit';
 import { User } from 'firebase/auth';
 import { ColorMode } from '../../theme/ThemeProvider';
 import { Household, Member, Request } from '../../types';
-import { addHousehold } from '../households/householdsActions';
+import {
+  addHousehold,
+  updateSelectedHouseholdName,
+} from '../households/householdsActions';
 import {
   getMembersByCurrentUserId,
   getRequestsByUserId,
@@ -92,6 +95,12 @@ export const userSlice = createSlice({
       .addCase(addHousehold.fulfilled, (state, action) => {
         state.memberProfiles.push(action.payload.member);
         state.isLoading = false;
+      })
+      .addCase(updateSelectedHouseholdName.fulfilled, (state, action) => {
+        state.selectedHousehold = {
+          ...state.selectedHousehold!,
+          name: action.payload.housholdName,
+        };
       });
   },
 });


### PR DESCRIPTION
This pull request introduces several changes to the household management functionality, including updates to state management and UI components to support editing household names. The changes also include some code cleanup and refactoring.

### Enhancements to Household Management:

* Added UI components and state management for editing household names in `SelectedHouseholdTopTabNav.tsx`. [[1]](diffhunk://#diff-42df7204896d23ed6ba29fb9837af373b71d7554abe149a7e596ea08eaec3b5eL7-R17) [[2]](diffhunk://#diff-42df7204896d23ed6ba29fb9837af373b71d7554abe149a7e596ea08eaec3b5eR36-R43) [[3]](diffhunk://#diff-42df7204896d23ed6ba29fb9837af373b71d7554abe149a7e596ea08eaec3b5eL46-R52) [[4]](diffhunk://#diff-42df7204896d23ed6ba29fb9837af373b71d7554abe149a7e596ea08eaec3b5eR65-R72) [[5]](diffhunk://#diff-42df7204896d23ed6ba29fb9837af373b71d7554abe149a7e596ea08eaec3b5eR93-R121)
* Updated the `updateHouseholdName` action to `updateSelectedHouseholdName` to reflect the selected household context in `householdsActions.ts`, `householdsSlice.ts`, and `userSlice.ts`. [[1]](diffhunk://#diff-55faa31b2b0b9c8a098b15dc4a6f0361eab02bdb638126241014f05b9d2bcbccL98-R117) [[2]](diffhunk://#diff-8420f271d5e7820111f5f32ab542cd49631471eff1aefecc5d03f9bdfd1e4c3aL7-R7) [[3]](diffhunk://#diff-8420f271d5e7820111f5f32ab542cd49631471eff1aefecc5d03f9bdfd1e4c3aL52-R60) [[4]](diffhunk://#diff-22a3219cb491ea04e8178418f1fc273c049f30ae8bc5027248ec9399e2c82797L6-R9) [[5]](diffhunk://#diff-22a3219cb491ea04e8178418f1fc273c049f30ae8bc5027248ec9399e2c82797R98-R103)

### Code Cleanup and Refactoring:

* Removed unused imports and refactored the `JoinHouseholdScreen.tsx` to use hooks for fetching user and household data. [[1]](diffhunk://#diff-3b51bd7274112e968e0de375b9a191c3bc303834042e738dd85a080fc8bb31c9L1-R1) [[2]](diffhunk://#diff-3b51bd7274112e968e0de375b9a191c3bc303834042e738dd85a080fc8bb31c9L12-L46)
* Updated the `TestHouseholds.tsx` to use the new `updateSelectedHouseholdName` action. [[1]](diffhunk://#diff-05e67579c8c01bd19cdf6f434ef5037ba842dc1a6c12bfcfa01e2ba76a479e35L10-R10) [[2]](diffhunk://#diff-05e67579c8c01bd19cdf6f434ef5037ba842dc1a6c12bfcfa01e2ba76a479e35L49-R49)
* Commented out the unused `useSelectedHousehold` hook in `user/hooks.ts`.