### PR TITLE
139 bugfix can only complete the same task once per day new label for new tasks

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -4,6 +4,15 @@ import { initializeApp } from 'firebase/app';
 import { getReactNativePersistence, initializeAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
+// const firebaseConfig = {
+//   apiKey: process.env.EXPO_PUBLIC_FIREBAS_API,
+//   authDomain: 'fire-base-db-90846.firebaseapp.com',
+//   projectId: 'fire-base-db-90846',
+//   storageBucket: 'fire-base-db-90846.appspot.com',
+//   messagingSenderId: '1084251965186',
+//   appId: '1:1084251965186:web:aad9371bc24596042a641b',
+// };
+
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBAS_API,
   authDomain: 'bank-app-b6a7e.firebaseapp.com',

--- a/firebase.ts
+++ b/firebase.ts
@@ -4,15 +4,6 @@ import { initializeApp } from 'firebase/app';
 import { getReactNativePersistence, initializeAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
-// const firebaseConfig = {
-//   apiKey: process.env.EXPO_PUBLIC_FIREBAS_API,
-//   authDomain: 'fire-base-db-90846.firebaseapp.com',
-//   projectId: 'fire-base-db-90846',
-//   storageBucket: 'fire-base-db-90846.appspot.com',
-//   messagingSenderId: '1084251965186',
-//   appId: '1:1084251965186:web:aad9371bc24596042a641b',
-// };
-
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBAS_API,
   authDomain: 'bank-app-b6a7e.firebaseapp.com',

--- a/screens/SelectedHouseholdScreen.tsx
+++ b/screens/SelectedHouseholdScreen.tsx
@@ -81,13 +81,13 @@ export default function SelectedHouseholdScreen({ navigation }: Props) {
               today,
               new Date(Date.parse(pastCompletionsOfThisTask[0].dateDone)),
             )
-          : 100;
+          : 10000;
 
       return (
         <>
-          {daysSinceLastCompleted > 99 ? (
+          {daysSinceLastCompleted > 9999 ? (
             <View>
-              <Badge size={24}>0</Badge>
+              <Badge size={24}>new</Badge>
             </View>
           ) : daysSinceLastCompleted > task.frequency ? (
             <View>


### PR DESCRIPTION
This pull request includes several updates to the `firebase.ts` and `screens` files to improve functionality and readability. The most important changes include updating the Firebase configuration, modifying the behavior of the `SelectedHouseholdScreen`, and enhancing the `TaskInfoScreen` to better handle task completion status.

### Firebase Configuration Update:

* [`firebase.ts`](diffhunk://#diff-d5decf055fcd75287ffdff74d64cd4f3cc6f595a5ef6e4bd1fdf6682d199cf51R7-R15): Updated the Firebase configuration by commenting out the old configuration and adding a new one.

### SelectedHouseholdScreen Modifications:

* [`screens/SelectedHouseholdScreen.tsx`](diffhunk://#diff-642883d5e08a44cc436a53367d79bdd0904823c6ebb937b27810b68b25d9ec61L84-R90): Changed the conditional logic to display a badge with "new" text instead of "0" when the number of days since the last task completion exceeds 9999.

### TaskInfoScreen Enhancements:

* [`screens/TaskInfoScreen.tsx`](diffhunk://#diff-e4420e9f36972bf3b734338e0e8d6116072a0c16cecee6f4a7dcec0a885593f9R14-R17): Imported additional selectors and utility functions (`todayAtMidnight`, `selectCompletedTasksByHousehold`) to enhance task handling.
* [`screens/TaskInfoScreen.tsx`](diffhunk://#diff-e4420e9f36972bf3b734338e0e8d6116072a0c16cecee6f4a7dcec0a885593f9R30-R39): Added logic to determine if a task has been completed today by the user and conditionally render the task completion button based on this status. [[1]](diffhunk://#diff-e4420e9f36972bf3b734338e0e8d6116072a0c16cecee6f4a7dcec0a885593f9R30-R39) [[2]](diffhunk://#diff-e4420e9f36972bf3b734338e0e8d6116072a0c16cecee6f4a7dcec0a885593f9R88) [[3]](diffhunk://#diff-e4420e9f36972bf3b734338e0e8d6116072a0c16cecee6f4a7dcec0a885593f9R100)